### PR TITLE
[FEATURE] App based authentication

### DIFF
--- a/bot/src/util/Auth.cs
+++ b/bot/src/util/Auth.cs
@@ -60,12 +60,12 @@ namespace Bot.Src.Utils
             DateTime now = DateTime.UtcNow;
             // delete a minitue from the current time to allow clock drift.
             long unixTime = new DateTimeOffset(now.AddMinutes(-1)).ToUnixTimeSeconds();
-            IEnumerable<Claim> claims = new Claim[]
-            {
+            IEnumerable<Claim> claims =
+            [
                 new(JwtRegisteredClaimNames.Iat, unixTime.ToString()),
                 new (JwtRegisteredClaimNames.Exp, (unixTime + (60 * 10)).ToString()), // 10 minutes
                 new(JwtRegisteredClaimNames.Iss, appid)
-            };
+            ];
             return GenerateSignedJWTToken(claims, privateKey);
         }
 

--- a/bot/src/util/Auth.cs
+++ b/bot/src/util/Auth.cs
@@ -5,7 +5,9 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Timers;
 using Microsoft.IdentityModel.Tokens;
+//
 
 namespace Bot.Src.Utils
 {
@@ -19,20 +21,16 @@ namespace Bot.Src.Utils
 
         }
         /// <summary>
-        /// Generates the singned JWT token, Using the private key.
+        /// Generates the singned JWT token, Using the private pem key string, so algoritm is RSA256.
         /// </summary>
-        public static string GenerateSignedJWTToken(string payload, string privateKey)
+        public static string GenerateSignedJWTToken(IEnumerable<Claim> claims, string privateKey)
         {
             RSA decodedPEMKey = DecodePrivatePEMKey(privateKey);
             RsaSecurityKey securityKey = new(decodedPEMKey);
             SigningCredentials credentials = new(securityKey, SecurityAlgorithms.RsaSha256);
-            Array claims = new[]{
-                new Claim(JwtRegisteredClaimNames.Sub, payload)
-                };
-
-            JwtSecurityToken token = new(issuer: "");
-
-            return "";
+            JwtSecurityToken token = new(claims: claims, signingCredentials: credentials);
+            // the generated bearer token
+            return new JwtSecurityTokenHandler().WriteToken(token);
         }
 
         /// <summary>
@@ -55,6 +53,20 @@ namespace Bot.Src.Utils
             RSA rsa = RSA.Create();
             rsa.ImportFromPem(privateKey);
             return rsa;
+        }
+
+        public static string GithubAppJWTToken(string appid, string privateKey)
+        {
+            DateTime now = DateTime.UtcNow;
+            // delete a minitue from the current time to allow clock drift.
+            long unixTime = new DateTimeOffset(now.AddMinutes(-1)).ToUnixTimeSeconds();
+            IEnumerable<Claim> claims = new Claim[]
+            {
+                new(JwtRegisteredClaimNames.Iat, unixTime.ToString()),
+                new (JwtRegisteredClaimNames.Exp, (unixTime + (60 * 10)).ToString()), // 10 minutes
+                new(JwtRegisteredClaimNames.Iss, appid)
+            };
+            return GenerateSignedJWTToken(claims, privateKey);
         }
 
     }

--- a/tests/src/util/AuthTests.cs
+++ b/tests/src/util/AuthTests.cs
@@ -8,6 +8,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Bot.Src.Utils;
 using System.Security.Cryptography;
+using System.Security.Claims;
 
 
 namespace Tests.Src.Utils
@@ -29,6 +30,30 @@ namespace Tests.Src.Utils
             using RSA rsa = RSA.Create();
             pemKey = rsa.ExportRSAPrivateKeyPem();
         }
+
+        [Fact]
+    public void TestGenerateSignedJWTToken()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new ("claim1", "value1"),
+            new ("claim2", "value2"),
+            new ("claim3", "value3")
+        };
+
+        // Act
+        string token = Authentication.GenerateSignedJWTToken(claims, pemKey);
+        var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+        // Assert
+        Assert.Equal("RS256", jwtToken.Header.Alg);
+        foreach (var claim in claims)
+        {
+            Assert.Equal(claim.Value, jwtToken.Claims.First(c => c.Type == claim.Type).Value);
+        }
+    }
+
         [Fact]
         public void TestIsTokenExpired()
         {

--- a/tests/src/util/AuthTests.cs
+++ b/tests/src/util/AuthTests.cs
@@ -7,6 +7,7 @@ using System.IdentityModel.Tokens.Jwt;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Bot.Src.Utils;
+using System.Security.Cryptography;
 
 
 namespace Tests.Src.Utils
@@ -15,18 +16,29 @@ namespace Tests.Src.Utils
 
     public class AuthTests
     {
+        // Arrange
+        private readonly string appId = "test_app_id";
+        private readonly SymmetricSecurityKey securityKey = new(Encoding.UTF8.GetBytes("ThisIsASecretKeyForEncryption32_"));
+        private readonly SigningCredentials hmac256SignedCredentials;
+
+        private readonly string pemKey;
+
+        public AuthTests()
+        {
+            hmac256SignedCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+            using RSA rsa = RSA.Create();
+            pemKey = rsa.ExportRSAPrivateKeyPem();
+        }
         [Fact]
         public void TestIsTokenExpired()
         {
-            // Arrange
-            SymmetricSecurityKey securityKey = new(Encoding.UTF8.GetBytes("ThisIsASecretKeyForEncryption32_"));
-            SigningCredentials credentials = new(securityKey, SecurityAlgorithms.HmacSha256);
+
 
             var tokenHandler = new JwtSecurityTokenHandler();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Expires = DateTime.UtcNow.AddMinutes(-1), // Expired token
-                SigningCredentials = credentials,
+                SigningCredentials = hmac256SignedCredentials,
                 NotBefore = DateTime.UtcNow.AddMinutes(-5), // Not valid before 5 minutes ago
 
             };
@@ -38,6 +50,19 @@ namespace Tests.Src.Utils
 
             // Assert
             Assert.True(isExpired);
+        }
+
+        [Fact]
+        public void TestGithubAppJWTToken()
+        {
+            // Act
+            string token = Authentication.GithubAppJWTToken(appId, pemKey);
+            JwtSecurityToken jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+            // Assert
+            Assert.Equal(appId, jwtToken.Claims.First(claim => claim.Type == "iss").Value);
+            Assert.True(long.Parse(jwtToken.Claims.First(claim => claim.Type == "iat").Value) <= DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+            Assert.True(long.Parse(jwtToken.Claims.First(claim => claim.Type == "exp").Value) >= DateTimeOffset.UtcNow.ToUnixTimeSeconds());
         }
     }
 


### PR DESCRIPTION
To authenticate as an app or generate an installation access token.

JWT must be signed using the RS256 algorithm.

Follows Github app-based specifications: [link](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts)

closes #66 